### PR TITLE
Get rid of PAT: github token should be enough.

### DIFF
--- a/.github/workflows/renovate-build.yml
+++ b/.github/workflows/renovate-build.yml
@@ -38,7 +38,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.NGINX_PAT }}
 
       - name: Set up Node.js
         uses:


### PR DESCRIPTION
To minimize the amount of secrets used, get rid of PAT. 
Github token (which is used by default) with contents:write permission is enough to commit changes into a PR branch.